### PR TITLE
[GF-02] Implementar búsqueda de archivos PDF

### DIFF
--- a/internal/search/google_searcher.go
+++ b/internal/search/google_searcher.go
@@ -1,5 +1,12 @@
 package search
 
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
 // GoogleSearcher implementa la interfaz Searcher utilizando la API de Google Custom Search.
 type GoogleSearcher struct {
 	APIKey   string
@@ -27,7 +34,36 @@ func NewGoogleSearcher(apiKey, engineID string) *GoogleSearcher {
 //   - Una lista de URLs de archivos PDF encontrados.
 //   - Un error si ocurre algún problema durante la búsqueda.
 func (g *GoogleSearcher) Search(domain string) ([]string, error) {
+	query := fmt.Sprintf("site:%s filetype:pdf", domain)
+	searchURL := fmt.Sprintf("https://www.googleapis.com/customsearch/v1?q=%s&key=%s&cx=%s",
+		url.QueryEscape(query), g.APIKey, g.EngineID)
+
+	fmt.Println("searchURL: ", searchURL)
+
+	resp, err := http.Get(searchURL)
+	if err != nil {
+		return nil, fmt.Errorf("error al realizar la solicitud HTTP: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("error en la respuesta HTTP: %s", resp.Status)
+	}
+
+	var result struct {
+		Items []struct {
+			Link string `json:"link"`
+		} `json:"items"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("error al parsear la respuesta JSON: %v", err)
+	}
+
 	var pdfURLs []string
+	for _, item := range result.Items {
+		pdfURLs = append(pdfURLs, item.Link)
+	}
 
 	return pdfURLs, nil
 }


### PR DESCRIPTION
This pull request introduces significant enhancements to the `GoogleSearcher` implementation in the `internal/search/google_searcher.go` file. The changes include adding necessary imports, constructing the search query URL, handling the HTTP request and response, and parsing the JSON response to extract PDF URLs.

Enhancements to `GoogleSearcher`:

* Added imports for `encoding/json`, `fmt`, `net/http`, and `net/url` to support the new functionality.
* Constructed the search query URL using `fmt.Sprintf` and `url.QueryEscape` to format the query string and escape special characters.
* Implemented an HTTP GET request to the Google Custom Search API and handled potential errors.
* Checked the HTTP response status code and handled non-OK responses appropriately.
* Parsed the JSON response to extract PDF URLs and appended them to the `pdfURLs` slice.