### PR TITLE
[GF-03] Agregar funcionalidad para descargar archivos a una carpeta temporal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor
 .env
+temp

--- a/internal/downloader/downloader.go
+++ b/internal/downloader/downloader.go
@@ -1,5 +1,13 @@
 package downloader
 
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+)
+
 // HTTPDownloader implementa la interfaz Downloader utilizando HTTP.
 type HTTPDownloader struct{}
 
@@ -19,5 +27,37 @@ func NewHTTPDownloader() *HTTPDownloader {
 func (d *HTTPDownloader) Download(urls []string) ([]string, error) {
 	var files []string
 
+	// Crear la carpeta "temp" si no existe
+	err := os.MkdirAll("temp", os.ModePerm)
+	if err != nil {
+		return nil, fmt.Errorf("error al crear la carpeta temp: %v", err)
+	}
+
+	// Descargar cada archivo
+	for _, url := range urls {
+		fileName := filepath.Join("temp", filepath.Base(url))
+		outFile, err := os.Create(fileName)
+		if err != nil {
+			return nil, fmt.Errorf("error al crear el archivo %s: %v", fileName, err)
+		}
+		defer outFile.Close()
+
+		resp, err := http.Get(url)
+		if err != nil {
+			return nil, fmt.Errorf("error al descargar %s: %v", url, err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("error en la respuesta HTTP al descargar %s: %s", url, resp.Status)
+		}
+
+		_, err = io.Copy(outFile, resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("error al guardar el archivo %s: %v", fileName, err)
+		}
+
+		files = append(files, fileName)
+	}
 	return files, nil
 }


### PR DESCRIPTION
This pull request introduces significant enhancements to the `HTTPDownloader` implementation in the `internal/downloader/downloader.go` file. The changes include importing necessary packages, creating a temporary directory for downloaded files, and handling the download process for multiple URLs.

Key changes:

### Enhancements to `HTTPDownloader`:

* Imported essential packages such as `fmt`, `io`, `net/http`, `os`, and `path/filepath` to support file downloading and error handling.
* Added functionality to create a "temp" directory if it does not exist, ensuring a dedicated space for downloaded files.
* Implemented a loop to download each file from the provided URLs, including error handling for file creation, HTTP requests, and file writing.