### PR TITLE
[GF-05] Ajustar el manejo de metadatos en OpenAIAnalyze

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor
 .env
 temp
+summary.md

--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -1,1 +1,64 @@
 package analyzer
+
+const prompt = `[INSTRUCCIONES DEL SISTEMA INICIO]
+
+A partir de los metadatos que te proporcionaré, tu tarea será identificar y describir cómo un atacante podría aprovechar esa información para comprometer un sistema. Genera un plan de acción detallado que incluya:
+
+Vectores de ataque potenciales:
+
+Analiza los nombres de los autores, herramientas utilizadas y otros detalles relevantes de los metadatos para identificar posibles ataques.
+Incluye ejemplos específicos de cómo se podría usar esta información para explotar el sistema.
+Tácticas de explotación:
+
+Describe cómo un atacante usaría cada dato relevante (e.g., versiones de software, permisos, identificadores únicos).
+Incluye ataques como:
+Ingeniería social o phishing.
+Explotación de vulnerabilidades conocidas en herramientas detectadas.
+Modificación o manipulación de los documentos.
+Pasos específicos:
+
+Detalla cada paso que el atacante podría seguir para llevar a cabo un ataque basado en la información extraída de los metadatos.
+Prioriza los vectores de ataque más efectivos o críticos.
+Resultados esperados:
+
+Describe qué tipo de acceso o daño podría lograr el atacante al usar estos métodos.
+Menciona qué tipo de información o sistemas podrían estar comprometidos.
+Formato de Respuesta:
+
+El plan de acción debe presentarse con las siguientes secciones:
+
+Resumen inicial:
+Breve descripción de los principales vectores de ataque detectados.
+Análisis de metadatos:
+Listado de los datos relevantes encontrados en los metadatos.
+Vectores de ataque detallados:
+Descripción de cada vector con pasos específicos.
+Prioridades de ataque:
+Clasificación de los ataques según su impacto o facilidad de ejecución.
+Resultados esperados:
+Explicación del posible impacto que tendría cada ataque.
+Ejemplo de Inicio del Informe:
+
+Plan de Acción para Explotación Basado en Metadatos
+Resumen Inicial
+A partir de los metadatos proporcionados, se identificaron múltiples vectores de ataque, incluyendo ingeniería social dirigida a autores como "Juan Carlos López Patiño" y explotación de vulnerabilidades en herramientas como Microsoft Word 2016 e iText 5.1.3.
+
+Análisis de Metadatos
+Los datos clave incluyen nombres de autores, identificadores únicos, herramientas utilizadas y permisos de archivo que podrían facilitar accesos no autorizados.
+
+Vectores de Ataque Detallados
+
+Ingeniería Social: Se puede personalizar un correo de phishing basado en el autor "Juan Carlos López Patiño".
+Explotación de Vulnerabilidades: Herramientas como iText 5.1.3 tienen vulnerabilidades conocidas, como ejecución remota de código.
+Manipulación de Archivos: Los documentos no linealizados pueden modificarse para incluir exploits.
+Prioridades de Ataque
+
+Ingeniería Social.
+Explotación de software vulnerable.
+Enumeración de directorios usando permisos débiles.
+Resultados Esperados
+Acceso a credenciales, manipulación de sistemas internos y posible control de documentos sensibles.
+[INSTRUCCIONES DEL SISTEMA FIN]
+[DATOS DEL USUARIO INICIO]
+%s
+[DATOS DEL USUARIO FIN]`

--- a/internal/analyzer/interface.go
+++ b/internal/analyzer/interface.go
@@ -4,17 +4,16 @@ import "github.com/whitejokeer/go-fear-the-foca/internal/metadata"
 
 // AnalysisResult representa el resultado del análisis de metadatos.
 type AnalysisResult struct {
-    FileName string
-    Summary  string
+	Summary string
 }
 
 // Analyzer define la interfaz para analizar metadatos.
 type Analyzer interface {
-    // Analyze procesa los metadatos proporcionados y retorna los resultados del análisis.
-    // Parámetros:
-    //   - metadataList: Lista de objetos Metadata a analizar.
-    // Retorna:
-    //   - Una lista de objetos AnalysisResult.
-    //   - Un error si ocurre algún problema durante el análisis.
-    Analyze(metadataList []metadata.Metadata) ([]AnalysisResult, error)
+	// Analyze procesa los metadatos proporcionados y retorna los resultados del análisis.
+	// Parámetros:
+	//   - metadataList: Lista de objetos Metadata a analizar.
+	// Retorna:
+	//   - Una lista de objetos AnalysisResult.
+	//   - Un error si ocurre algún problema durante el análisis.
+	Analyze(metadataList []metadata.Metadata) (*AnalysisResult, error)
 }

--- a/internal/analyzer/openai_analyzer.go
+++ b/internal/analyzer/openai_analyzer.go
@@ -1,6 +1,13 @@
+// internal/analyzer/openai_analyzer.go
+
 package analyzer
 
 import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
 	openai "github.com/sashabaranov/go-openai"
 	"github.com/whitejokeer/go-fear-the-foca/internal/metadata"
 )
@@ -8,11 +15,13 @@ import (
 // OpenAIAnalyzer implementa la interfaz Analyzer utilizando la API de OpenAI.
 type OpenAIAnalyzer struct {
 	Client *openai.Client
+	Prompt string
 }
 
 // NewOpenAIAnalyzer crea una nueva instancia de OpenAIAnalyzer.
 // Parámetros:
 //   - apiKey: Clave de API de OpenAI.
+//   - prompt: Prompt personalizado para el análisis.
 //
 // Retorna:
 //   - Una instancia de OpenAIAnalyzer.
@@ -30,8 +39,72 @@ func NewOpenAIAnalyzer(apiKey string) *OpenAIAnalyzer {
 // Retorna:
 //   - Una lista de objetos AnalysisResult.
 //   - Un error si ocurre algún problema durante el análisis.
-func (o *OpenAIAnalyzer) Analyze(metadataList []metadata.Metadata) ([]AnalysisResult, error) {
-	var results []AnalysisResult
+func (o *OpenAIAnalyzer) Analyze(metadataList []metadata.Metadata) (*AnalysisResult, error) {
+	ctx := context.Background()
 
-	return results, nil
+	// Convertir todos los metadatos a una sola cadena
+	allMetadataStr := formatAllMetadata(metadataList)
+
+	// Crear el prompt personalizado utilizando el que ya tienes
+	prompt := fmt.Sprintf(prompt, allMetadataStr)
+
+	// Crear la solicitud a la API de OpenAI
+	req := openai.ChatCompletionRequest{
+		Model: openai.GPT4o,
+		Messages: []openai.ChatCompletionMessage{
+			{
+				Role:    openai.ChatMessageRoleSystem,
+				Content: "Eres un experto en ciberseguridad que analiza metadatos de documentos para identificar posibles riesgos.",
+			},
+			{
+				Role:    openai.ChatMessageRoleUser,
+				Content: prompt,
+			},
+		},
+	}
+
+	// Llamar a la API de OpenAI
+	resp, err := o.Client.CreateChatCompletion(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("error al llamar a la API de OpenAI: %v", err)
+	}
+
+	// Extraer la respuesta del asistente
+	summary := resp.Choices[0].Message.Content
+
+	// Guardar el resumen en un archivo
+	file, err := os.Create("internal/report/summary.md")
+	if err != nil {
+		return nil, fmt.Errorf("error al crear el archivo: %v", err)
+	}
+	defer file.Close()
+
+	_, err = file.WriteString(summary)
+	if err != nil {
+		return nil, fmt.Errorf("error al escribir en el archivo: %v", err)
+	}
+
+	results := AnalysisResult{
+		Summary: summary,
+	}
+
+	return &results, nil
+}
+
+// formatAllMetadata convierte la lista de metadatos en una cadena legible.
+// Parámetros:
+//   - metadataList: Lista de objetos Metadata.
+//
+// Retorna:
+//   - Una cadena formateada de todos los metadatos.
+func formatAllMetadata(metadataList []metadata.Metadata) string {
+	var builder strings.Builder
+	for _, md := range metadataList {
+		builder.WriteString(fmt.Sprintf("Archivo: %s\n", md.FileName))
+		for key, value := range md.Properties {
+			builder.WriteString(fmt.Sprintf("%s: %v\n", key, value))
+		}
+		builder.WriteString("\n")
+	}
+	return builder.String()
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1,79 +1,80 @@
 package app
 
 import (
-    "log"
+	"log"
 
-    "github.com/whitejokeer/go-fear-the-foca/internal/analyzer"
-    "github.com/whitejokeer/go-fear-the-foca/internal/config"
-    "github.com/whitejokeer/go-fear-the-foca/internal/downloader"
-    "github.com/whitejokeer/go-fear-the-foca/internal/metadata"
-    "github.com/whitejokeer/go-fear-the-foca/internal/report"
-    "github.com/whitejokeer/go-fear-the-foca/internal/search"
+	"github.com/whitejokeer/go-fear-the-foca/internal/analyzer"
+	"github.com/whitejokeer/go-fear-the-foca/internal/config"
+	"github.com/whitejokeer/go-fear-the-foca/internal/downloader"
+	"github.com/whitejokeer/go-fear-the-foca/internal/metadata"
+	"github.com/whitejokeer/go-fear-the-foca/internal/report"
+	"github.com/whitejokeer/go-fear-the-foca/internal/search"
 )
 
 // App es la estructura principal de la aplicación.
 // Contiene la configuración y las implementaciones de las interfaces.
 type App struct {
-    Config     *config.Config
-    Searcher   search.Searcher
-    Downloader downloader.Downloader
-    Extractor  metadata.Extractor
-    Analyzer   analyzer.Analyzer
-    Reporter   report.Reporter
+	Config     *config.Config
+	Searcher   search.Searcher
+	Downloader downloader.Downloader
+	Extractor  metadata.Extractor
+	Analyzer   analyzer.Analyzer
+	Reporter   report.Reporter
 }
 
 // NewApp crea una nueva instancia de App con las implementaciones predeterminadas.
 // Parámetros:
 //   - cfg: Configuración de la aplicación.
+//
 // Retorna una instancia de App.
 func NewApp(cfg *config.Config) *App {
-    return &App{
-        Config:     cfg,
-        Searcher:   search.NewGoogleSearcher(cfg.SearchEngineAPIKey, cfg.SearchEngineID),
-        Downloader: downloader.NewHTTPDownloader(),
-        Extractor:  metadata.NewPDFExtractor(),
-        Analyzer:   analyzer.NewOpenAIAnalyzer(cfg.OpenAIAPIKey),
-        Reporter:   report.NewHTMLReporter(),
-    }
+	return &App{
+		Config:     cfg,
+		Searcher:   search.NewGoogleSearcher(cfg.SearchEngineAPIKey, cfg.SearchEngineID),
+		Downloader: downloader.NewHTTPDownloader(),
+		Extractor:  metadata.NewPDFExtractor(),
+		Analyzer:   analyzer.NewOpenAIAnalyzer(cfg.OpenAIAPIKey),
+		Reporter:   report.NewHTMLReporter(),
+	}
 }
 
 // Run ejecuta el flujo principal de la aplicación.
 // Retorna un error si ocurre algún problema durante la ejecución.
 func (a *App) Run() error {
-    // Paso 1: Buscar archivos
-    urls, err := a.Searcher.Search(a.Config.Domain)
-    if err != nil {
-        return err
-    }
-    log.Printf("Se encontraron %d archivos", len(urls))
+	// Paso 1: Buscar archivos
+	urls, err := a.Searcher.Search(a.Config.Domain)
+	if err != nil {
+		return err
+	}
+	log.Printf("Se encontraron %d archivos", len(urls))
 
-    // Paso 2: Descargar archivos
-    files, err := a.Downloader.Download(urls)
-    if err != nil {
-        return err
-    }
-    log.Printf("Se descargaron %d archivos", len(files))
+	// Paso 2: Descargar archivos
+	files, err := a.Downloader.Download(urls)
+	if err != nil {
+		return err
+	}
+	log.Printf("Se descargaron %d archivos", len(files))
 
-    // Paso 3: Extraer metadatos
-    metadataList, err := a.Extractor.Extract(files)
-    if err != nil {
-        return err
-    }
-    log.Printf("Se extrajeron metadatos de %d archivos", len(metadataList))
+	// Paso 3: Extraer metadatos
+	metadataList, err := a.Extractor.Extract(files)
+	if err != nil {
+		return err
+	}
+	log.Printf("Se extrajeron metadatos de %d archivos", len(metadataList))
 
-    // Paso 4: Analizar metadatos
-    analysis, err := a.Analyzer.Analyze(metadataList)
-    if err != nil {
-        return err
-    }
-    log.Println("Análisis completado")
+	// Paso 4: Analizar metadatos
+	analysis, err := a.Analyzer.Analyze(metadataList)
+	if err != nil {
+		return err
+	}
+	log.Println("Análisis completado")
 
-    // Paso 5: Generar reporte
-    err = a.Reporter.Generate(analysis, a.Config.OutputDir)
-    if err != nil {
-        return err
-    }
-    log.Println("Reporte generado exitosamente")
+	// Paso 5: Generar reporte
+	err = a.Reporter.Generate(analysis, a.Config.OutputDir)
+	if err != nil {
+		return err
+	}
+	log.Println("Reporte generado exitosamente")
 
-    return nil
+	return nil
 }

--- a/internal/report/html_reporter.go
+++ b/internal/report/html_reporter.go
@@ -21,6 +21,6 @@ func NewHTMLReporter() *HTMLReporter {
 //
 // Retorna:
 //   - Un error si ocurre algún problema durante la generación del informe.
-func (h *HTMLReporter) Generate(results []analyzer.AnalysisResult, outputDir string) error {
+func (h *HTMLReporter) Generate(results *analyzer.AnalysisResult, outputDir string) error {
 	return nil
 }

--- a/internal/report/interface.go
+++ b/internal/report/interface.go
@@ -4,11 +4,11 @@ import "github.com/whitejokeer/go-fear-the-foca/internal/analyzer"
 
 // Reporter define la interfaz para generar informes.
 type Reporter interface {
-    // Generate crea un informe basado en los resultados del análisis.
-    // Parámetros:
-    //   - results: Lista de objetos AnalysisResult.
-    //   - outputDir: Directorio donde se guardará el informe.
-    // Retorna:
-    //   - Un error si ocurre algún problema durante la generación del informe.
-    Generate(results []analyzer.AnalysisResult, outputDir string) error
+	// Generate crea un informe basado en los resultados del análisis.
+	// Parámetros:
+	//   - results: Lista de objetos AnalysisResult.
+	//   - outputDir: Directorio donde se guardará el informe.
+	// Retorna:
+	//   - Un error si ocurre algún problema durante la generación del informe.
+	Generate(results *analyzer.AnalysisResult, outputDir string) error
 }


### PR DESCRIPTION
This pull request introduces significant changes to the `internal/analyzer` package, primarily focusing on enhancing the metadata analysis functionality using the OpenAI API. The changes include the addition of a detailed prompt for analysis, modifications to the `Analyzer` interface and its implementation, and adjustments to the reporting mechanism to handle the new analysis results format.

### Enhancements to metadata analysis:

* Added a comprehensive prompt in `internal/analyzer/analyzer.go` to guide the OpenAI model in generating detailed attack plans based on metadata.
* Updated the `Analyzer` interface in `internal/analyzer/interface.go` to return a single `AnalysisResult` object instead of a list.
* Implemented the `OpenAIAnalyzer` in `internal/analyzer/openai_analyzer.go` to use the OpenAI API for metadata analysis, including formatting metadata and handling API responses. [[1]](diffhunk://#diff-bc99fc87f4f1d6d24f9e8c424751d6f149b0eb630439820ff01782694638edddR1-R24) [[2]](diffhunk://#diff-bc99fc87f4f1d6d24f9e8c424751d6f149b0eb630439820ff01782694638edddL33-R109)

### Adjustments to reporting:

* Modified the `Generate` method in `internal/report/html_reporter.go` to accept a single `AnalysisResult` object.
* Updated the `Reporter` interface in `internal/report/interface.go` to reflect the change in the `Generate` method parameter.